### PR TITLE
Mark find(withPublicKey pubKey:SecKey) public in SecIdentity+SelfSigned.swift

### DIFF
--- a/SelfSignedCert/SecIdentity+SelfSigned.swift
+++ b/SelfSignedCert/SecIdentity+SelfSigned.swift
@@ -72,7 +72,7 @@ extension SecIdentity
      * - parameter withPublicKey: the public key that should be used to find the identity, based on it's digest
      * - returns: The identity if found, or `nil`.
      */
-    static func find(withPublicKey pubKey:SecKey) -> SecIdentity? {
+    public static func find(withPublicKey pubKey:SecKey) -> SecIdentity? {
         guard let identities = findAll(withPublicKey: pubKey), identities.count == 1 else {
             return nil
         }


### PR DESCRIPTION
I have a use case where I need reuse the created certificate. Making the find method public allows me to do this with ease. 